### PR TITLE
Implemented using unique names for images at deploy-on-push

### DIFF
--- a/src/com/ft/jenkins/git/GitUtils.groovy
+++ b/src/com/ft/jenkins/git/GitUtils.groovy
@@ -55,3 +55,11 @@ public String getMostRecentGitTag() {
   echo "Retrieved most recent git tag: ${extractedGitVersion}"
   return extractedGitVersion
 }
+
+public String getLatestCommit() {
+  return sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+}
+
+public String getShortLatestCommit() {
+  return getLatestCommit().take(6)
+}


### PR DESCRIPTION
Also set the name of the build.
Tested on https://k8s-jenkins-poc.in.ft.com/job/k8s-deployment/job/apps-deployment/job/coco-diamond-auto-deploy/job/deploy-on-push%252Fk8s%252Fhelm-integration/2/