### PR TITLE
Added target env as a value when installing the helm chart.

### DIFF
--- a/src/com/ft/jenkins/DeploymentUtils.groovy
+++ b/src/com/ft/jenkins/DeploymentUtils.groovy
@@ -48,7 +48,7 @@ public executeAppsDeployment(Cluster targetCluster, List<String> appsToDeploy, S
 
       echo "Using app config file ${configurationFileName} to deploy with helm"
 
-      sh "helm upgrade ${app} ${chartFolderLocation} -i -f ${configurationFileName} --set region=${region}"
+      sh "helm upgrade ${app} ${chartFolderLocation} -i -f ${configurationFileName} --set region=${region} --set target_env=${env.name}"
     }
   })
 }


### PR DESCRIPTION
Tested on API policy component:
- here failed because of laking the value: https://k8s-jenkins-poc.in.ft.com/job/k8s-deployment/job/utils/job/deploy-upp-helm-chart/293/
- here it succeeded after introducing the code in the PR: https://k8s-jenkins-poc.in.ft.com/job/k8s-deployment/job/utils/job/deploy-upp-helm-chart/294/

The commit on API policy component: https://github.com/Financial-Times/api-policy-component/commit/a36d22783cb95adef685ada8a8321ae451ca7cbf