### PR TITLE
Add GLB URL for the corresponding publishing environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
 *.iml
 target/
+/.settings/
+/bin/
+/.project
+/.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,9 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <groovy.version>2.4.8</groovy.version>
 
-    <junit.jupiter.version>5.0.2</junit.jupiter.version>
-    <junit.platform.version>1.0.2</junit.platform.version>
+    <maven.surefire-plugin.version>2.22.0</maven.surefire-plugin.version>
+    <junit.jupiter.version>5.2.0</junit.jupiter.version>
+    <junit.platform.version>1.2.0</junit.platform.version>
     <mockito.core.version>2.13.0</mockito.core.version>
     <jenkins.pipeline.unit.version>1.0</jenkins.pipeline.unit.version>
     <jenkins-test-harness.version>2.34</jenkins-test-harness.version>
@@ -106,7 +107,7 @@
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>${maven.surefire-plugin.version}</version>
         <dependencies>
           <dependency>
             <groupId>org.junit.platform</groupId>

--- a/src/com/ft/jenkins/DeploymentUtils.groovy
+++ b/src/com/ft/jenkins/DeploymentUtils.groovy
@@ -84,7 +84,8 @@ public executeAppsDeployment(Cluster targetCluster, List<String> appsToDeploy, S
           "--set region=${region} " +
           "--set target_env=${env.name} " +
           "--set __ext.target_cluster.sub_domain=${env.getClusterSubDomain(targetCluster, region)} " +
-          "${getClusterUrlsAsHelmValues(env, region)}"
+          "${getClusterUrlsAsHelmValues(env, region)} " +
+          "${getGlbUrlsAsHelmValues(env)}"
       sh "helm upgrade ${app} ${chartFolderLocation} -i --timeout 1200 -f ${configurationFileName} ${additionalHelmValues}"
     }
   })
@@ -95,6 +96,14 @@ public String getClusterUrlsAsHelmValues(Environment environment, String region)
   for (Cluster cluster : environment.clusters) {
     String clusterUrl = environment.getEntryPointUrl(cluster, region)
     result += " --set cluster.${cluster.label}.url=${clusterUrl}"
+  }
+  return result
+}
+
+public String getGlbUrlsAsHelmValues(Environment environment) {
+  String result = ""
+  environment.glbMap.each { entry ->
+    result += " --set glb.${entry.key.toLowerCase()}.url=${entry.value}"
   }
   return result
 }

--- a/src/com/ft/jenkins/Environment.groovy
+++ b/src/com/ft/jenkins/Environment.groovy
@@ -17,6 +17,9 @@ class Environment implements Serializable {
   /*  The application clusters that an environment has*/
   List<Cluster> clusters = []
 
+  /** The GLB addresses an environment may wish to know about. */
+  Map<String,String> glbMap = [:]
+  
   /*  Mapping between region+cluster and their respective Kubernetes api servers. */
   Map<String, String> clusterToApiServerMap
 
@@ -38,6 +41,10 @@ class Environment implements Serializable {
     return null
   }
 
+  public String getGlbUrl(Cluster cluster) {
+    return glbMap.get(cluster.toString())
+  }
+  
   public String getClusterSubDomain(Cluster cluster, String region = null) {
     String entryPointUrl = getEntryPointUrl(cluster, region)
     if (entryPointUrl == null) {

--- a/src/com/ft/jenkins/EnvsRegistry.groovy
+++ b/src/com/ft/jenkins/EnvsRegistry.groovy
@@ -14,6 +14,9 @@ class EnvsRegistry implements Serializable {
             ("eu-" + Cluster.DELIVERY)  : "https://upp-dev-cj-delivery-eu-api.ft.com",
             ("eu-" + Cluster.PUBLISHING): "https://upp-dev-cj-publish-eu-api.ft.com"
     ]
+    devCJ.glbMap = [
+        (Cluster.PUBLISHING.toString()): "https://upp-dev-cj-publish-eu.ft.com"
+    ]
 
     Environment k8s = new Environment()
     k8s.name = "k8s"
@@ -25,6 +28,9 @@ class EnvsRegistry implements Serializable {
         ("eu-" + Cluster.PUBLISHING.toString()): "https://upp-k8s-dev-publish-eu-api.ft.com",
         ("eu-" + Cluster.NEO4J.toString()): "https://upp-k8s-neo4j-eu-api.ft.com"
     ]
+    k8s.glbMap = [
+        (Cluster.PUBLISHING.toString()): "https://upp-k8s-dev-publish-eu.ft.com"
+    ]
 
     Environment stagingPAC = new Environment()
     stagingPAC.name = "stagingpac"
@@ -34,6 +40,9 @@ class EnvsRegistry implements Serializable {
     stagingPAC.clusterToApiServerMap = [
         ("eu-" + Cluster.PAC.toString()): "https://pac-staging-eu-api.ft.com",
         ("us-" + Cluster.PAC.toString()): "https://pac-staging-us-api.ft.com",
+    ]
+    stagingPAC.glbMap = [
+        (Cluster.PUBLISHING.toString()): "https://upp-staging-publish.ft.com"
     ]
 
     Environment prodPAC = new Environment()
@@ -45,7 +54,10 @@ class EnvsRegistry implements Serializable {
         ("eu-" + Cluster.PAC.toString()): "https://pac-prod-eu-api.ft.com",
         ("us-" + Cluster.PAC.toString()): "https://pac-prod-us-api.ft.com",
     ]
-    
+    prodPAC.glbMap = [
+        (Cluster.PUBLISHING.toString()): "https://upp-prod-publish.ft.com"
+    ]
+
     Environment gcPAC = new Environment()
     gcPAC.name = "gcpac"
     gcPAC.slackChannel = "#k8s-pipeline-notif"
@@ -68,6 +80,9 @@ class EnvsRegistry implements Serializable {
         ("eu-" + Cluster.NEO4J): "https://upp-staging-neo4j-eu-api.ft.com",
         ("us-" + Cluster.NEO4J): "https://upp-staging-neo4j-us-api.ft.com"
     ]
+    staging.glbMap = [
+        (Cluster.PUBLISHING.toString()): "https://upp-staging-publish.ft.com"
+    ]
 
     Environment prod = new Environment()
     prod.name = Environment.PROD_NAME
@@ -81,6 +96,9 @@ class EnvsRegistry implements Serializable {
         ("us-" + Cluster.PUBLISHING): "https://upp-prod-publish-us-api.ft.com",
         ("eu-" + Cluster.NEO4J): "https://upp-prod-neo4j-eu-api.ft.com",
         ("us-" + Cluster.NEO4J): "https://upp-prod-neo4j-us-api.ft.com"
+    ]
+    prod.glbMap = [
+        (Cluster.PUBLISHING.toString()): "https://upp-prod-publish.ft.com"
     ]
 
     envs = [devCJ, k8s, stagingPAC, staging, gcPAC, prodPAC, prod]

--- a/test-src/com/ft/jenkins/DeploymentUtilTest.java
+++ b/test-src/com/ft/jenkins/DeploymentUtilTest.java
@@ -59,4 +59,30 @@ public class DeploymentUtilTest {
     );
 
   }
+
+  @Test
+  public void thatGlbUrlsAreReturnedAsHelmParams() {
+    Environment environment = new Environment();
+    environment.setClusters(Arrays.asList(Cluster.PAC));
+    HashMap<String, String> glbMap = new HashMap<>();
+    
+    glbMap.put(Cluster.PUBLISHING.toString(), "https://upp-test-publishing.ft.com");
+    environment.setGlbMap(glbMap);
+
+    String actual = deploymentUtils.getGlbUrlsAsHelmValues(environment);
+
+    assertEquals(
+        " --set glb.publishing.url=https://upp-test-publishing.ft.com",
+        actual);
+  }
+
+  @Test
+  public void thatMissingGlbUrlsAreIgnored() {
+    Environment environment = new Environment();
+    environment.setClusters(Arrays.asList(Cluster.PAC));
+
+    String actual = deploymentUtils.getGlbUrlsAsHelmValues(environment);
+
+    assertEquals("", actual);
+  }
 }

--- a/test-src/com/ft/jenkins/EnvironmentUnitTest.java
+++ b/test-src/com/ft/jenkins/EnvironmentUnitTest.java
@@ -67,4 +67,28 @@ public class EnvironmentUnitTest {
 
     assertNull(env.getClusterSubDomain(Cluster.DELIVERY));
   }
+
+  @Test
+  public void thatGlbNameIsReturned() {
+    Environment env = new Environment();
+    env.setName("k8s");
+    env.setClusters(Arrays.asList(Cluster.DELIVERY, Cluster.PUBLISHING));
+    env.setRegions(Arrays.asList("eu"));
+
+    HashMap<String, String> glbMap = new HashMap<>();
+    glbMap.put(Cluster.PUBLISHING.toString(), "https://upp-test-publish.ft.com");
+    env.setGlbMap(glbMap);
+
+    assertEquals("https://upp-test-publish.ft.com", env.getGlbUrl(Cluster.PUBLISHING));
+  }
+
+  @Test
+  public void thatMissingGlbNameIsHandled() {
+    Environment env = new Environment();
+    env.setName("k8s");
+    env.setClusters(Arrays.asList(Cluster.DELIVERY, Cluster.PUBLISHING));
+    env.setRegions(Arrays.asList("eu"));
+
+    assertNull(env.getGlbUrl(Cluster.PUBLISHING));
+  }
 }


### PR DESCRIPTION
Some PAC services need to know where publishing services are located,
and also some UPP services should have a GLB address for publishing
services rather than a region-specific one, so I have added a mapping to
the Environment object.

Also upgraded the Junit and Surefire dependencies to fix OOM failures
when any test case failed.