### PR TITLE
Konstruktor to changeapi

### DIFF
--- a/Pipeline_integration_points.md
+++ b/Pipeline_integration_points.md
@@ -43,8 +43,8 @@ Some of java apps integrate with the FT's maven repository hosted in a Nexus ins
 **Jenkins credential:** ***[nexus.credentials
 ](https://upp-k8s-jenkins.in.ft.com/job/k8s-deployment/credentials/store/folder/domain/_/credential/nexus.credentials/)***
 
-### Konstructor CR API integration
-For automatically managing Change Requests, the pipeline integrates with the Konstructor API.
+### Change API integration
+For automatically managing Change Requests, the pipeline integrates with the Change API.
 
-**Jenkins credential:** ***[ft.cr-api.key
-](https://upp-k8s-jenkins.in.ft.com/job/k8s-deployment/credentials/store/folder/domain/_/credential/ft.cr-api.key/)***
+**Jenkins credential:** ***[ft.change-api.key
+](https://upp-k8s-jenkins.in.ft.com/job/k8s-deployment/credentials/store/folder/domain/_/credential/ft.change-api.key/)***

--- a/src/com/ft/jenkins/changerequests/ChangeRequestOpenData.groovy
+++ b/src/com/ft/jenkins/changerequests/ChangeRequestOpenData.groovy
@@ -3,16 +3,7 @@ package com.ft.jenkins.changerequests
 class ChangeRequestOpenData implements Serializable {
   String ownerEmail
   String summary
-  String description
-  String details
   ChangeRequestEnvironment environment
-  String changeCategory
-  String riskProfile = "Low"
-  String willThereBeAnOutage = "NO"
-  Date scheduledStartDate
-  Date scheduledEndDate
-  String resourceOne = "universal.publishing.platform@ft.com"
-  List<String> serviceIds = ['ContentAPI']
-  boolean notify = true
   String notifyChannel
+  String systemCode
 }

--- a/src/com/ft/jenkins/changerequests/ChangeRequestsUtils.groovy
+++ b/src/com/ft/jenkins/changerequests/ChangeRequestsUtils.groovy
@@ -45,7 +45,7 @@ public String open(ChangeRequestOpenData crData, String credentialId = DEFAULT_C
                            requestBody: bodyJson)
   }
   def responseJson = new JsonSlurper().parseText(response.content)
-  return responseJson.changeRequests[0].name
+  return responseJson.changeRequests?.getAt(0)?.name
 }
 
 private String getUkFormattedDate(Date date) {

--- a/src/com/ft/jenkins/provision/ProvisionerUtil.groovy
+++ b/src/com/ft/jenkins/provision/ProvisionerUtil.groovy
@@ -92,11 +92,11 @@ private void sendFinishUpdateNotification(String fullClusterName, String updateR
 
 private String openChangeRequest(ClusterUpdateInfo updateInfo, String fullClusterName, String updateReason,
                                  Environment updatedEnv) {
-  /*  do not open change requests for Development environments. 
+  /*  do not open change requests for Development environments. */
   if (updateInfo.envType == EnvType.DEVELOPMENT) {
     return null
   }
- */
+
   try {
     ChangeRequestOpenData data = new ChangeRequestOpenData()
     String buildAuthor = new ParamUtils().jenkinsBuildAuthor

--- a/src/com/ft/jenkins/provision/ProvisionerUtil.groovy
+++ b/src/com/ft/jenkins/provision/ProvisionerUtil.groovy
@@ -92,11 +92,11 @@ private void sendFinishUpdateNotification(String fullClusterName, String updateR
 
 private String openChangeRequest(ClusterUpdateInfo updateInfo, String fullClusterName, String updateReason,
                                  Environment updatedEnv) {
-  /*  do not open change requests for Development environments. */
+  /*  do not open change requests for Development environments. 
   if (updateInfo.envType == EnvType.DEVELOPMENT) {
     return null
   }
-
+ */
   try {
     ChangeRequestOpenData data = new ChangeRequestOpenData()
     String buildAuthor = new ParamUtils().jenkinsBuildAuthor

--- a/vars/upperEnvsBuildAndDeploy.groovy
+++ b/vars/upperEnvsBuildAndDeploy.groovy
@@ -4,7 +4,6 @@ import com.ft.jenkins.DeploymentUtils
 import com.ft.jenkins.DeploymentUtilsConstants
 import com.ft.jenkins.Environment
 import com.ft.jenkins.EnvsRegistry
-import com.ft.jenkins.changerequests.ChangeRequestCloseData
 import com.ft.jenkins.changerequests.ChangeRequestEnvironment
 import com.ft.jenkins.changerequests.ChangeRequestOpenData
 import com.ft.jenkins.changerequests.ChangeRequestsUtils
@@ -102,11 +101,6 @@ public void initiateDeploymentToEnvironment(String targetEnvName, String chartNa
         deployAppsToEnvironmentRegions(regionsToDeployTo, chartName, version, environment)
 
         remainingRegionsToDeployTo.removeAll(regionsToDeployTo)
-
-        // close the CR only after we deployed to all the regions of the environment
-        if (remainingRegionsToDeployTo.isEmpty()) {
-          closeCr(crId, environment)
-        }
 
         stage("validate apps in ${environment.getNamesWithRegions(regionsToDeployTo)}") {
           sendSlackMessageForValidation(releaseInfo, environment, appsPerCluster, regionsToDeployTo,
@@ -253,46 +247,18 @@ private String openCr(String approver, GithubReleaseInfo releaseInfo, Environmen
   try {
     ChangeRequestOpenData data = new ChangeRequestOpenData()
     data.ownerEmail = "${approver}@ft.com"
+    data.systemCode = "${chartName}"
     data.summary = "Deploying chart ${chartName}:${releaseInfo.tagName} with apps ${computeSimpleTextForAppsToDeploy(appsPerCluster)} in ${environment.name}"
-    if (releaseInfo.description) {
-      data.description = releaseInfo.description
-    } else if (releaseInfo.title) {
-      data.description = releaseInfo.title
-    }
-    else {
-      data.description = releaseInfo.tagName
-    }
-
     data.details = releaseInfo.title ? releaseInfo.title : releaseInfo.tagName
-
     data.environment = environment.name == Environment.PROD_NAME ? ChangeRequestEnvironment.Production :
                        ChangeRequestEnvironment.Test
     data.notifyChannel = environment.slackChannel
-    data.notify = true
 
     ChangeRequestsUtils crUtils = new ChangeRequestsUtils()
     return crUtils.open(data)
   }
   catch (e) { //  do not fail if the CR interaction fail
     echo "Error while opening CR for release ${releaseInfo.getTagName()}: ${e.message} "
-  }
-}
-
-private void closeCr(String crId, Environment environment) {
-  if (crId == null) {
-    return
-  }
-
-  try {
-    ChangeRequestCloseData data = new ChangeRequestCloseData()
-    data.notifyChannel = environment.slackChannel
-    data.id = crId
-
-    ChangeRequestsUtils crUtils = new ChangeRequestsUtils()
-    crUtils.close(data)
-  }
-  catch (e) { //  do not fail if the CR interaction fail
-    echo "Error while closing CR ${crId}: ${e.message} "
   }
 }
 

--- a/vars/upperEnvsBuildAndDeploy.groovy
+++ b/vars/upperEnvsBuildAndDeploy.groovy
@@ -249,7 +249,6 @@ private String openCr(String approver, GithubReleaseInfo releaseInfo, Environmen
     data.ownerEmail = "${approver}@ft.com"
     data.systemCode = "${chartName}"
     data.summary = "Deploying chart ${chartName}:${releaseInfo.tagName} with apps ${computeSimpleTextForAppsToDeploy(appsPerCluster)} in ${environment.name}"
-    data.details = releaseInfo.title ? releaseInfo.title : releaseInfo.tagName
     data.environment = environment.name == Environment.PROD_NAME ? ChangeRequestEnvironment.Production :
                        ChangeRequestEnvironment.Test
     data.notifyChannel = environment.slackChannel


### PR DESCRIPTION
Changes are tested both with a Helm deployment and Cluster update. More information:

1. Removed the Close Change Request functions, since the new workflow is for the Change Requests to close automatically (https://financialtimes.slack.com/archives/CG397FZMZ/p1559310168002100)
2. Changed the Open Change Request function to use the Change API instead.
3. Changed the way the Open Change Request funcion is being called and used in both Provisioner Utils and upperEnvsBuildAndDeploy