### PR TITLE
Make eks-publish-staging-us the active cluster

### DIFF
--- a/src/com/ft/jenkins/cluster/Clusters.groovy
+++ b/src/com/ft/jenkins/cluster/Clusters.groovy
@@ -142,8 +142,9 @@ class Clusters implements Serializable {
                       apiServer: "https://upp-staging-publish-eu-api.upp.ft.com",
                       publicEndpoint: "https://upp-staging-publish-eu.upp.ft.com"
               ),
-              ("${Region.US}-${ClusterType.PUBLISHING}".toString()): newEntry(
-                      apiServer: "https://upp-staging-publish-us-api.upp.ft.com",
+              ("${Region.US}-${ClusterType.PUBLISHING}".toString()): newEksEntry(
+                      eksClusterName: "eks-publish-staging-us",
+                      apiServer: "https://425D1781C1BAB80CACC6D3FFA45C6F19.gr7.us-east-1.eks.amazonaws.com",
                       publicEndpoint: "https://upp-staging-publish-us.upp.ft.com"
               )
       ]


### PR DESCRIPTION
# Description

## Why

This is the final step just before switching the cluster instance to be serviced by an EKS backed K8S cluster.

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
